### PR TITLE
Condition to handle NaNs

### DIFF
--- a/news/NaNhandling.rst
+++ b/news/NaNhandling.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* When a slice of all `NaN`s is encountered, the `NaN`s are now set to zero.
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -370,6 +370,10 @@ class Gui(tk.Frame):
             plane = self.cube[:, self.plane_num.get(), :]
         elif self.axis.get() == 2:
             plane = self.cube[:, :, self.plane_num.get()]
+
+        if np.all(np.isnan(plane)):
+            plane = np.zeros_like(plane)
+
         nan_ratio = np.count_nonzero(np.isnan(plane)) / plane.size
         self.localmax["text"] = "{}".format(np.format_float_scientific(np.nanmax(plane), 1))
         self.localmin["text"] = "{}".format(np.format_float_scientific(np.nanmin(plane), 1))


### PR DESCRIPTION
I had a chat with Bob this morning about the RuntimeWarning. The goal of the test is to verify that the `applycutoff` method is working as expected for a given `qmin` and `qmax`. We agreed that the test was okay. We came up with two possible fixes for this through modification of the source code. 

1) If a slice of all NaNs is encountered, set all those NaNs to zero. This we thought to be simpler and is the solution in this PR. 
2) Find a different way to represent NaN values in the data such as replacing all NaNs with zeros. This seems to have a lot of moving parts and could cause more trouble. 

The below images are from the GUI where all NaNs are present and where some NaNs are present (for reference). These images were taken after applying the edits made on this PR. @sbillinge does this seem valid to you? 

![Screenshot 2024-10-28 at 11 01 38 AM](https://github.com/user-attachments/assets/dbe85b08-5043-48ca-a961-f76e8aa1689b)
![Screenshot 2024-10-28 at 11 01 51 AM](https://github.com/user-attachments/assets/ab63db62-0e7a-4b3b-b5c2-61fbc40a9e4d)
![Screenshot 2024-10-28 at 11 02 01 AM](https://github.com/user-attachments/assets/52717e23-d993-4d92-940e-c830d4409ced)
