### PR TITLE
Fixes Qmin Qmax should be included after masking.  Not the current behavior.

### DIFF
--- a/news/gt.rst
+++ b/news/gt.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* qmin/qmax limits in reciprocal space grid so qmin and qmax are not excluded
+
+**Security:**
+
+* <news item>

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,3 +4,4 @@ codecov
 coverage
 pytest-cov
 pytest-env
+pytest-mock

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -291,14 +291,11 @@ class Gui(tk.Frame):
         self.slider.grid(row=0, column=0, padx=10, pady=10, sticky=tk.N + tk.E + tk.S + tk.W)
 
         if not self.loaded:
-
             fig, ax = plt.subplots(figsize=(4.95, 4.95))
             fig = plt.gcf()
             DPI = fig.get_dpi()
             fig.set_size_inches(500 / float(DPI), 500 / float(DPI))
-
             self.plane_num.set(np.shape(self.cube)[0] // 2)
-
             if self.axis.get() == 0:
                 self.im = plt.imshow(self.cube[self.plane_num.get(), :, :])
             elif self.axis.get() == 1:
@@ -319,7 +316,6 @@ class Gui(tk.Frame):
             self.canvas.draw()
             self.canvas.get_tk_widget().pack(side=tk.LEFT, fill=tk.BOTH, expand=1)
             self.loaded = True
-
         else:
             self.plot_plane()
             self.transformed = False

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -484,7 +484,7 @@ class Gui(tk.Frame):
             r2_outer = qmax**2
             i, j, k = np.meshgrid(np.arange(xdim), np.arange(ydim), np.arange(zdim))
             r2 = (i - xdim // 2) ** 2 + (j - ydim // 2) ** 2 + (k - zdim // 2) ** 2
-            mask = (r2 <= r2_inner) | (r2 >= r2_outer)  # True if voxel is out of range
+            mask = (r2 < r2_inner) | (r2 > r2_outer)  # True if voxel is out of range
             sphere[mask] = np.nan  # therefore set to np.nan if out of range
 
             if self.space.get():

--- a/tests/test_fourigui.py
+++ b/tests/test_fourigui.py
@@ -1,6 +1,8 @@
+import tkinter as tk
 import unittest
 
 import h5py
+import numpy as np
 
 from diffpy.fourigui.fourigui import Gui
 
@@ -144,6 +146,82 @@ class TestGui(unittest.TestCase):
 
         # then
         self.assertTrue(self.test_gui.transformed and self.test_gui.transcutted)
+
+
+def test_applycutoff(mocker):
+    root = tk.Tk()
+    fg = Gui()
+    # qmin of 1 and qmax of 2 is expected to leave the central pixel and corner
+    # pixels as NaN's
+    mocker.patch.object(fg.qminentry, "get", return_value=1.0)
+    mocker.patch.object(fg.qmaxentry, "get", return_value=2.0)
+    mocker.patch.object(fg, "plot_plane")  # we don't want it to plot anything so intercept
+    fg.cutted = False
+    fg.cube = np.ones((5, 5, 5))
+    expected_ones = np.ones((5, 5, 5))
+    expected_recip = np.array(
+        [
+            [
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, np.nan, 1, np.nan, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+            ],
+            [
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+            ],
+            [
+                [np.nan, np.nan, 1, np.nan, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [1, 1, np.nan, 1, 1],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, np.nan, 1, np.nan, np.nan],
+            ],
+            [
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, 1, 1, 1, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+            ],
+            [
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, np.nan, 1, np.nan, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+                [np.nan, np.nan, np.nan, np.nan, np.nan],
+            ],
+        ]
+    )
+    # test the case where fg.space is 0
+    fg.applycutoff()
+    np.testing.assert_array_equal(fg.cube_reci, expected_ones)
+    np.testing.assert_array_equal(fg.cube_recicut, expected_recip)
+    root.destroy()  # Clean up Tkinter instance
+
+    # test the case where fg.space is 1
+    root = tk.Tk()
+    fg = Gui()
+    # qmin of 1 and qmax of 2 is expected to leave the central pixel and corner
+    # pixels as NaN's
+    mocker.patch.object(fg.qminentry, "get", return_value=1)
+    mocker.patch.object(fg.qmaxentry, "get", return_value=2)
+    mocker.patch.object(
+        fg, "fft"
+    )  # we don't want it to do the fft so intercept.  Should be tested separately (fixme).
+    fg.cutted = False
+    fg.cube_reci = np.ones((5, 5, 5))
+    fg.cube = np.ones((5, 5, 5))
+    mocker.patch.object(fg.space, "get", return_value=1)
+    fg.applycutoff()
+    np.testing.assert_array_equal(fg.cube_real, expected_ones)
+    np.testing.assert_array_equal(fg.cube_recicut, expected_recip)
+    root.destroy()  # Clean up Tkinter instance
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- **mask on reciprocal space is greater than not greater than equal**
- **news**
