### PR TITLE
Add comment for `RuntimeWarning` surpression

### DIFF
--- a/news/test.rst
+++ b/news/test.rst
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* Surpress `RuntimeWarning` in tests for the `applycutoff` function
+* Surpress the `RuntimeWarning` in tests for the `applycutoff` function
 
 **Security:**
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -105,7 +105,8 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "10")
         self.test_gui.qmaxentry.insert(0, "40")
 
-        # surpressed RuntimeWarning so warning isn't generated when test encounters slice of all NaNs
+        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate runtimewarnings when it
+        # encounters slices that are all nans. capture these so tests pass cleanly without warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             # when
@@ -121,8 +122,9 @@ class TestGui(unittest.TestCase):
         self.test_gui.cube = self.test_sofq
         self.test_gui.qminentry.insert(0, "15")
         self.test_gui.qmaxentry.insert(0, "35")
-
-        # surpressed RuntimeWarning so warning isn't generated when test encounters slice of all NaNs
+        
+        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate runtimewarnings when it
+        # encounters slices that are all nans. capture these so tests pass cleanly without warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             # when

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -121,7 +121,7 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "15")
         self.test_gui.qmaxentry.insert(0, "35")
 
-        # when
+        # surpressed RuntimeWarning so warning isn't generated when test encounters slice of all NaNs
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             self.test_gui.applycutoff()

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -105,9 +105,10 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "10")
         self.test_gui.qmaxentry.insert(0, "40")
 
-        # when
+        # surpressed RuntimeWarning so warning isn't generated when test encounters slice of all NaNs
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
+            # when
             self.test_gui.applycutoff()
         result = self.test_gui.cube
 
@@ -124,6 +125,7 @@ class TestGui(unittest.TestCase):
         # surpressed RuntimeWarning so warning isn't generated when test encounters slice of all NaNs
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
+            # when
             self.test_gui.applycutoff()
         result = self.test_gui.cube
 

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -105,8 +105,9 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "10")
         self.test_gui.qmaxentry.insert(0, "40")
 
-        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate runtimewarnings when it
-        # encounters slices that are all nans. capture these so tests pass cleanly without warnings
+        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate 
+        # runtimewarnings when it # encounters slices that are all nans. capture these so tests pass cleanly 
+        # without warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             # when
@@ -123,8 +124,9 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "15")
         self.test_gui.qmaxentry.insert(0, "35")
 
-        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate runtimewarnings when it
-        # encounters slices that are all nans. capture these so tests pass cleanly without warnings
+        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate 
+        # runtimewarnings when it # encounters slices that are all nans. capture these so tests pass cleanly 
+        # without warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
             # when

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -122,7 +122,7 @@ class TestGui(unittest.TestCase):
         self.test_gui.cube = self.test_sofq
         self.test_gui.qminentry.insert(0, "15")
         self.test_gui.qmaxentry.insert(0, "35")
-        
+
         # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate runtimewarnings when it
         # encounters slices that are all nans. capture these so tests pass cleanly without warnings
         with warnings.catch_warnings():

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -105,8 +105,8 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "10")
         self.test_gui.qmaxentry.insert(0, "40")
 
-        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate 
-        # runtimewarnings when it # encounters slices that are all nans. capture these so tests pass cleanly 
+        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate
+        # runtimewarnings when it # encounters slices that are all nans. capture these so tests pass cleanly
         # without warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)
@@ -124,8 +124,8 @@ class TestGui(unittest.TestCase):
         self.test_gui.qminentry.insert(0, "15")
         self.test_gui.qmaxentry.insert(0, "35")
 
-        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate 
-        # runtimewarnings when it # encounters slices that are all nans. capture these so tests pass cleanly 
+        # Desired behavior is nans in the arrays below qmin and above qmax.  As a result, np.nanmax will generate
+        # runtimewarnings when it # encounters slices that are all nans. capture these so tests pass cleanly
         # without warnings
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=RuntimeWarning)


### PR DESCRIPTION
Instead of removing, I moved the `# when` comment. All other test in this file follow the same format so I figured it would be worth keeping since it does help code readability. 