### PR TITLE
change minimum python version to 3.11

### DIFF
--- a/news/pythonversion.rst
+++ b/news/pythonversion.rst
@@ -12,7 +12,7 @@
 
 **Removed:**
 
-* * Removed support for python 3.10
+* Removed support for python `<3.11`
 
 **Fixed:**
 

--- a/news/pythonversion.rst
+++ b/news/pythonversion.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* * Removed support for python 3.10
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/tutorialdoc.rst
+++ b/news/tutorialdoc.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Add tutorial to API
+* Add tutorial to documentation
 
 **Changed:**
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ maintainers = [
 description = "Tool for visualizing 3D diffraction and PDF Images."
 keywords = ['diffraction', 'pdf', 'pair distribution function', 'gui']
 readme = "README.rst"
-requires-python = ">=3.10, <3.14"
+requires-python = ">=3.11, <3.14"
 classifiers = [
         'Development Status :: 5 - Production/Stable',
         'Environment :: Console',


### PR DESCRIPTION
closes #37. 

Also, I changed a past news item on this PR. The wording was inaccurate (replaced `API` with `documentation`). This is what was actually done on the PR associated with this news item. 