### PR TITLE
Fixed typos in docstring and comment in README.rst and fourigui.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -128,6 +128,3 @@ Contact
 -------
 
 For more information on diffpy.fourigui please visit the project `web-page <https://diffpy.github.io/>`_ or email Prof. Simon Billinge at sb2896@columbia.edu.
-
-
-This is a test

--- a/README.rst
+++ b/README.rst
@@ -122,7 +122,7 @@ trying to commit again.
 
 Improvements and fixes are always appreciated.
 
-Before contribuing, please read our `Code of Conduct <https://github.com/diffpy/diffpy.fourigui/blob/main/CODE_OF_CONDUCT.rst>`_.
+Before contributing, please read our `Code of Conduct <https://github.com/diffpy/diffpy.fourigui/blob/main/CODE_OF_CONDUCT.rst>`_.
 
 Contact
 -------

--- a/README.rst
+++ b/README.rst
@@ -128,3 +128,6 @@ Contact
 -------
 
 For more information on diffpy.fourigui please visit the project `web-page <https://diffpy.github.io/>`_ or email Prof. Simon Billinge at sb2896@columbia.edu.
+
+
+This is a test

--- a/news/doc.rst
+++ b/news/doc.rst
@@ -1,0 +1,24 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+Fixed 1 typo in README.rst
+Fixed 1 typo in fourigui.py
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -461,7 +461,7 @@ class Gui(tk.Frame):
         reassign all voxels with distance smaller than qmin and greater than qmax
         from the central voxel to 0.0
         qmin, qmax is loaded from the qmin, qmax input panel
-        currently opperates in units of pixels
+        currently operates in units of pixels
         """
         if not self.cutted:
 


### PR DESCRIPTION
I fixed some typos in docstring and comment in README.rst and fourigui.py