### PR TITLE
Fixed warning in fourigui.py code

### DIFF
--- a/news/warning.rst
+++ b/news/warning.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+Warning fixed in fourigui.py adding line 397 `axes = list(range(len(size)))` and modifying line 399 `fftholder = np.fft.fftn(fftholder, s=size, axes=axes, norm="ortho")`
+
+**Security:**
+
+* <news item>

--- a/news/warning.rst
+++ b/news/warning.rst
@@ -8,7 +8,7 @@
 
 **Deprecated:**
 
-* <news item>
+* Deprecation warning fixed for axes in np.fft in fourigui.py
 
 **Removed:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-Warning fixed in fourigui.py adding line 397 `axes = list(range(len(size)))` and modifying line 399 `fftholder = np.fft.fftn(fftholder, s=size, axes=axes, norm="ortho")`
+* <news item>
 
 **Security:**
 

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -394,7 +394,7 @@ class Gui(tk.Frame):
         def perform_fft(fftholder):
             fftholder = np.nan_to_num(fftholder)
             size = list(fftholder.shape)
-            axes = list(range(len(size))) 
+            axes = list(range(len(size)))
             fftholder = np.fft.ifftshift(fftholder)
             fftholder = np.fft.fftn(fftholder, s=size, axes=axes, norm="ortho")
             fftholder = np.fft.fftshift(fftholder)

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -394,8 +394,9 @@ class Gui(tk.Frame):
         def perform_fft(fftholder):
             fftholder = np.nan_to_num(fftholder)
             size = list(fftholder.shape)
+            axes = list(range(len(size))) 
             fftholder = np.fft.ifftshift(fftholder)
-            fftholder = np.fft.fftn(fftholder, s=size, norm="ortho")
+            fftholder = np.fft.fftn(fftholder, s=size, axes=axes, norm="ortho")
             fftholder = np.fft.fftshift(fftholder)
             fftholder = fftholder.real
             return fftholder


### PR DESCRIPTION
Closes #22 Warning fixed in fourigui.py adding line 397 `axes = list(range(len(size)))` and modifying line 399 `fftholder = np.fft.fftn(fftholder, s=size, axes=axes, norm="ortho")`
