### PR TITLE
Fixed `np.fft.fftn()` deprecation

### DIFF
--- a/news/numpy_dep.rst
+++ b/news/numpy_dep.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* Fixed deprecation warning presented by numpy2
+
+**Security:**
+
+* <news item>

--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -394,8 +394,9 @@ class Gui(tk.Frame):
         def perform_fft(fftholder):
             fftholder = np.nan_to_num(fftholder)
             size = list(fftholder.shape)
+            axes = list(range(fftholder.ndim))
             fftholder = np.fft.ifftshift(fftholder)
-            fftholder = np.fft.fftn(fftholder, s=size, norm="ortho")
+            fftholder = np.fft.fftn(fftholder, s=size, axes=axes, norm="ortho")
             fftholder = np.fft.fftshift(fftholder)
             fftholder = fftholder.real
             return fftholder


### PR DESCRIPTION
closes #22 Fix numpy2 deprecation by specifying axes. Discussed on this PR https://github.com/diffpy/diffpy.fourigui/pull/56. More specifically, on this comment https://github.com/diffpy/diffpy.fourigui/pull/56#issuecomment-2465246435