### PR TITLE
Add h5py import to documentation build

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -37,4 +37,3 @@ Release Notes
 
 * debug.py file for running tests
 * Removed support for python `<3.11`
-

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,6 +46,10 @@ extensions = [
     "m2r",
 ]
 
+autodoc_mock_imports = [
+    "h5py",
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/news/h5py.rst
+++ b/news/h5py.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* Documentation-level fix.
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>

--- a/news/h5py.rst
+++ b/news/h5py.rst
@@ -1,6 +1,6 @@
 **Added:**
 
-* Documentation-level fix.
+* <news item>
 
 **Changed:**
 
@@ -16,7 +16,7 @@
 
 **Fixed:**
 
-* <news item>
+* Added Sphinx imports to fix documentation rendering.
 
 **Security:**
 


### PR DESCRIPTION
Should populate the documentation when merged.