### PR TITLE
Build GitHub pages by addition write permissions 

### DIFF
--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -1,14 +1,15 @@
-name: Build and Deploy Docs
+name: Deploy Documentation on Release
 
 on:
   release:
-    types:
-      - published
+    types: [published]
   workflow_dispatch:
 
 jobs:
   docs:
-    uses: Billingegroup/release-scripts/.github/workflows/_publish-docs-on-release.yml@v0
+    permissions:
+      contents: write
+    uses: bobleesj/release-scripts/.github/workflows/_publish-docs-on-release.yml@v0
     with:
       project: diffpy.fourigui
       c_extension: false


### PR DESCRIPTION
We want to build docs when published (GitHub release) or by workflow dispatch. 