### PR TITLE
Add headless to `true` to doc GitHub build workflow to `sudo apt-get install -y xvfb`

### DIFF
--- a/.github/workflows/publish-docs-on-release.yml
+++ b/.github/workflows/publish-docs-on-release.yml
@@ -13,3 +13,4 @@ jobs:
     with:
       project: diffpy.fourigui
       c_extension: false
+      headless: true

--- a/news/doc-build.rst
+++ b/news/doc-build.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* <news item>
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* API docstrings rendered with Linux GitHub CI by installing xvfb
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
The goal of this PR is to ensure we can render API doc strings with our linux CI. 

Closes https://github.com/diffpy/diffpy.fourigui/issues/70 - fixing API docstrings
Closes https://github.com/diffpy/diffpy.fourigui/issues/18 - build API doc
Closes https://github.com/diffpy/diffpy.fourigui/issues/33 - fixing doc link