### PR TITLE
Add tkinter and matplotlib to autodoc_mock_imports to render API Doc via Linux CI

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -48,6 +48,8 @@ extensions = [
 
 autodoc_mock_imports = [
     "h5py",
+    "tkinter",
+    "matplotlib"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -46,11 +46,7 @@ extensions = [
     "m2r",
 ]
 
-autodoc_mock_imports = [
-    "h5py",
-    "tkinter",
-    "matplotlib"
-]
+autodoc_mock_imports = ["h5py", "tkinter", "matplotlib"]
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]


### PR DESCRIPTION
<img width="1071" alt="Screenshot 2024-12-09 at 6 13 30 PM" src="https://github.com/user-attachments/assets/a4ee788e-efb3-4fdc-b231-14e18bb353dd">

@sbillinge @cadenmyers13 Working now, using the same reusable workflow.

https://bobleesj.github.io/diffpy.fourigui/api/diffpy.fourigui.html

After merged, please deploy doc by workflow dispatch!