### PR TITLE
skpkg: rename variable cutted as cutoff_applied

### DIFF
--- a/src/diffpy/fourigui/fourigui.py
+++ b/src/diffpy/fourigui/fourigui.py
@@ -30,7 +30,7 @@ class Gui(tk.Frame):
         self.transformed = (
             False  # denotes whether dataset is Fourier transformed
         )
-        self.cutted = (
+        self.cutoff_applied = (
             False  # denotes whether cutoff frequencies are applied to dataset
         )
         self.transcutted = (
@@ -358,7 +358,7 @@ class Gui(tk.Frame):
             self.plot_plane()
             self.transformed = False
             self.transcutted = False
-            self.cutted = False
+            self.cutoff_applied = False
             self.cutoff.set(0)
             self.space.set(0)
 
@@ -519,7 +519,7 @@ class Gui(tk.Frame):
         --------
         nothing
         """
-        if not self.cutted:
+        if not self.cutoff_applied:
             xdim, ydim, zdim = self.cube.shape
             sphere = np.ones((xdim, ydim, zdim))
             qmin = float(self.qminentry.get())
@@ -553,7 +553,7 @@ class Gui(tk.Frame):
                 self.plot_plane()
                 self.intensity_upd_global()
 
-            self.cutted = True
+            self.cutoff_applied = True
 
         else:
             if self.space.get():  # in real space
@@ -585,7 +585,7 @@ class Gui(tk.Frame):
                 self.cube = self.cube_real
             else:
                 self.cube = self.cube_reci
-        self.cutted = False
+        self.cutoff_applied = False
         self.transcutted = False
         self.applycutoff()
 

--- a/tests/test_fourigui.py
+++ b/tests/test_fourigui.py
@@ -18,7 +18,7 @@ class TestGui(unittest.TestCase):
     def test_init(self):
         self.assertFalse(self.test_gui.loaded)
         self.assertFalse(self.test_gui.transformed)
-        self.assertFalse(self.test_gui.cutted)
+        self.assertFalse(self.test_gui.cutoff_applied)
         self.assertFalse(self.test_gui.transcutted)
         self.assertFalse(self.test_gui.cutoff.get())
         self.assertFalse(self.test_gui.space.get())
@@ -81,7 +81,7 @@ class TestGui(unittest.TestCase):
         self.assertTrue(
             not self.test_gui.transformed and self.test_gui.transcutted
         )
-        # self.assertTrue(self.test_gui.cutted)
+        # self.assertTrue(self.test_gui.cutoff_applied)
 
     def test_fft_001(self):
         # given
@@ -170,7 +170,7 @@ def test_applycutoff(mocker):
     mocker.patch.object(
         fg, "plot_plane"
     )  # we don't want it to plot anything so intercept
-    fg.cutted = False
+    fg.cutoff_applied = False
     fg.cube = np.ones((5, 5, 5))
     expected_ones = np.ones((5, 5, 5))
     expected_recip = np.array(
@@ -229,7 +229,7 @@ def test_applycutoff(mocker):
         fg, "fft"
     )  # we don't want it to do the fft so intercept.
     # Should be tested separately (fixme).
-    fg.cutted = False
+    fg.cutoff_applied = False
     fg.cube_reci = np.ones((5, 5, 5))
     fg.cube = np.ones((5, 5, 5))
     mocker.patch.object(fg.space, "get", return_value=1)


### PR DESCRIPTION
closes #83 rename `cutted` as `cutoff_applied` in `fourigui.py` and its tests