### PR TITLE
fix: fix documentation on fourigui

### DIFF
--- a/docs/source/api/diffpy.fourigui.rst
+++ b/docs/source/api/diffpy.fourigui.rst
@@ -10,12 +10,6 @@
     :undoc-members:
     :show-inheritance:
 
-Subpackages
------------
-
-.. toctree::
-   diffpy.fourigui.example_package
-
 Submodules
 ----------
 

--- a/news/documentation-fix.rst
+++ b/news/documentation-fix.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No News Added: fix build on documentation
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge ready to review. I reviewed the online documentation on pre-release on `PyPI` and noticed that on `api` page we failed to load the source of api. This is because we didn't delete the `example-package` module, so it breaks at that point and fails to load the other stuffs afterwards. 
This is the current online documentation of the pre-release.
<img width="1349" height="995" alt="Screenshot 2026-04-07 at 5 42 16 PM" src="https://github.com/user-attachments/assets/23c42a58-f634-4140-9b53-991de4d573da" />
And this is the local re-rendering after deleting the `example-package` stuff.
<img width="1344" height="988" alt="Screenshot 2026-04-07 at 5 41 40 PM" src="https://github.com/user-attachments/assets/6c7049e7-3de1-4797-b9de-1e02e0338f64" />
