### PR TITLE
chore: fix documentation again.

### DIFF
--- a/docs/source/api/diffpy.fourigui.rst
+++ b/docs/source/api/diffpy.fourigui.rst
@@ -13,8 +13,8 @@
 Submodules
 ----------
 
-|module|
---------
+Module contents
+---------------
 
 .. automodule:: diffpy.fourigui.fourigui
     :members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -53,6 +53,7 @@ extensions = [
     "m2r2",
 ]
 
+autodoc_mock_imports = ["h5py", "tkinter", "matplotlib"]
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/news/documentation-replacement.rst
+++ b/news/documentation-replacement.rst
@@ -1,0 +1,23 @@
+**Added:**
+
+* No News Added: fix build on documentation
+
+**Changed:**
+
+* <news item>
+
+**Deprecated:**
+
+* <news item>
+
+**Removed:**
+
+* <news item>
+
+**Fixed:**
+
+* <news item>
+
+**Security:**
+
+* <news item>


### PR DESCRIPTION
@sbillinge ready to review again. It seems that apart from the previous issue, the `module` is not defined, so it breaks the build again. so I replace it to a static one and let's see whether the api could show.